### PR TITLE
Update mongodb connection to use env

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -224,21 +224,20 @@
       }
     },
     "mongodb": {
-      "version": "3.1.0-beta4",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.0-beta4.tgz",
-      "integrity": "sha512-nJAK59fFlMWTdEJaTyGp3HeerkIahnupoMNjbszPJVnO63/36aFnlWHqpYrrJwj9GKlmb47YWBIvNo6fdrUL4Q==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.0.8.tgz",
+      "integrity": "sha512-mj7yIUyAr9xnO2ev8pcVJ9uX7gSum5LLs1qIFoWLxA5Il50+jcojKtaO1/TbexsScZ9Poz00Pc3b86GiSqJ7WA==",
       "requires": {
-        "mongodb-core": "3.1.0-beta4"
+        "mongodb-core": "3.0.8"
       }
     },
     "mongodb-core": {
-      "version": "3.1.0-beta4",
-      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.1.0-beta4.tgz",
-      "integrity": "sha512-aiwUKBGmFZwBx4CdC1iK5kjZyk0zhDxQ0edRtpTZUkk1jyWkdzYd6GEA6wMl7O6ZX/dOiFM2ujkrUR7+vkqJPw==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.0.8.tgz",
+      "integrity": "sha512-dFxfhH9N7ohuQnINyIl6dqEF8sYOE0WKuymrFf3L3cipJNrx+S8rAbNOTwa00/fuJCjBMJNFsaA+R2N16//UIw==",
       "requires": {
         "bson": "1.0.6",
-        "require_optional": "1.0.1",
-        "saslprep": "1.0.0"
+        "require_optional": "1.0.1"
       }
     },
     "ms": {
@@ -340,12 +339,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-    },
-    "saslprep": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.0.tgz",
-      "integrity": "sha512-5lvKUEQ7lAN5/vPl5d3k8FQeDbEamu9kizfATfLLWV5h6Mkh1xcieR1FSsJkcSRUk49lF2tAW8gzXWVwtwZVhw==",
-      "optional": true
     },
     "semver": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   "dependencies": {
     "body-parser": "^1.18.2",
     "express": "^4.16.3",
-    "mongodb": "^3.1.0-beta4"
+    "mongodb": "^3.0.8"
   }
 }

--- a/server.js
+++ b/server.js
@@ -38,12 +38,14 @@ app.post('/signup', function (req, res) {
 
         // insert text into database collection
         client.db().collection("emails").insertOne(email, (err, collection) => {
-            if (err) throw err;
+            if (err) {
+                console.log(err);
+                return res.json(err);
+            }
             console.log("Record inserted successfully ", email);
+            res.end();
         });
     });
-
-    return res.sendStatus(200);
 
 });
 

--- a/server.js
+++ b/server.js
@@ -21,7 +21,7 @@ app.use(bodyParser.json({
 app.use(express.static("public"));
 
 // set the MongoDB to environment or localhost
-var MONGODB_URI = process.env.MONGODB_URI || "mongodb://localhost";
+var MONGODB_URI = process.env.MONGODB_URI || "mongodb://localhost/cakemix";
 
 // create post route for email sign up
 app.post('/signup', function (req, res) {
@@ -30,22 +30,17 @@ app.post('/signup', function (req, res) {
     console.log("email is ", email);
 
     // connect to the database and the collection
+    // this uses v 3 of node.js driver, returning a client instead of the db in a connection 
+    // see https://github.com/mongodb/node-mongodb-native/blob/master/CHANGES_3.0.0.md for details
     mongo.connect(MONGODB_URI, function (err, client) {
         if (err) throw err;
-
-        var db = client.db("cakemix");
-
         console.log("connected to database successfully");
 
         // insert text into database collection
-        db.collection("emails").insertOne(email, (err, collection) => {
+        client.db().collection("emails").insertOne(email, (err, collection) => {
             if (err) throw err;
             console.log("Record inserted successfully ", email);
         });
-    });
-
-    res.set({
-        'Access-Control-Allow-Origin': '*'
     });
 
     return res.sendStatus(200);


### PR DESCRIPTION
I hit some problems when deploying to heroku due to a change in how the updated version of the node.js mongodb client returns in new versions. 

(see https://github.com/mongodb/node-mongodb-native/blob/master/CHANGES_3.0.0.md for details)

This should make it so the env variable can be properly passed in prep for deployment.